### PR TITLE
Implement Dependabot auto-merge strategy for patch/minor updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
+      - ".github/**"
 
 jobs:
   backend-lint:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
+      - ".github/**"
   schedule:
     - cron: "0 19 * * 0" # 毎週月曜 04:00 JST
 

--- a/docs/adr/003-dependabot-auto-merge-strategy.md
+++ b/docs/adr/003-dependabot-auto-merge-strategy.md
@@ -1,0 +1,48 @@
+# ADR-003: Dependabot 自動マージ戦略
+
+## ステータス
+
+採用
+
+## コンテキスト
+
+Dependabot が weekly で 3 エコシステム（bundler / npm / github-actions）の更新 PR を作成しているが、すべて手動マージしているため PR が溜まりやすい。マージの手間を減らしつつ、破壊的変更を見逃さない運用を決める必要があった。
+
+## 検討した案
+
+### 案A: 完全手動マージ
+
+すべての Dependabot PR を人が確認してマージする。
+
+- メリット: 最も安全。変更内容を毎回目視確認できる
+- デメリット: PR が溜まりやすく、放置すると Dependabot PR だらけになる
+
+### 案B: patch/minor は自動、major は手動
+
+semver に基づいて自動マージの範囲を制御する。patch と minor アップデートは CI 通過後に自動マージし、major アップデートのみ手動確認する。
+
+- メリット: リスクと手間のバランスが良い。業界で最も一般的な運用パターン
+- デメリット: semver を正しく守らないライブラリでは patch/minor でも破壊的変更が入る可能性がある
+
+### 案C: dev dependencies のみ自動マージ
+
+テストツール・linter 等の開発依存だけ自動マージし、本番依存は手動確認する。
+
+- メリット: 本番に影響するライブラリは必ず人が確認できる
+- デメリット: 本番依存の PR は結局溜まる。案A と同じ問題が本番依存で残る
+
+## 決定
+
+**案B を採用。** GitHub Actions ワークフロー（`dependabot-auto-merge.yml`）で `dependabot/fetch-metadata` を使い、major 以外の Dependabot PR に `gh pr merge --auto` を実行する。
+
+## 採用理由
+
+- 学習・実験用リポジトリであり、本番障害のリスクがない
+- CI（RSpec, RuboCop, ESLint, Vitest）とセキュリティチェック（Brakeman, bundler-audit, npm audit）が既にあり、自動マージ前のガードとして機能する
+- 設定を消すだけで手動運用に戻せる（可逆性が高い）
+- 今後本番運用に近づける場合は、案C（dev dependencies のみ自動）への段階的移行が容易
+
+## 補足
+
+- `gh pr merge --auto` の動作には、リポジトリ設定で「Allow auto-merge」の有効化と Branch Protection Rule（必須ステータスチェック）の設定が必要
+- CI / Security ワークフローの paths フィルタに `.github/**` を追加し、github-actions エコシステムの PR でもチェックが実行されるようにする（Branch Protection との整合性確保）


### PR DESCRIPTION
## Summary

Implement an automated merge strategy for Dependabot pull requests to reduce manual review overhead while maintaining safety for major version updates. This follows a semver-based approach where patch and minor updates are automatically merged after CI passes, while major updates remain manual.

## Changes

- **Added ADR-003** documenting the decision to adopt patch/minor auto-merge strategy with rationale and alternatives considered
- **Created `dependabot-auto-merge.yml` workflow** that:
  - Runs on all pull requests from Dependabot
  - Uses `dependabot/fetch-metadata@v2` to determine update type
  - Automatically enables merge for non-major version updates
  - Requires CI and security checks to pass via branch protection rules
- **Updated CI and security workflows** to include `.github/**` in path filters, ensuring GitHub Actions dependency updates also trigger required checks

## Implementation Details

- Auto-merge is conditional on `update-type != 'version-update:semver-major'`, allowing patch and minor updates to merge automatically while major updates require manual review
- Leverages existing CI (RSpec, RuboCop, ESLint, Vitest) and security checks (Brakeman, bundler-audit, npm audit) as gatekeepers
- Strategy is reversible—can be disabled by removing the workflow
- Supports three ecosystems: bundler, npm, and github-actions

https://claude.ai/code/session_01GdbSVsKt1zQwX3sVoD9rbU