### PR TITLE
Group React dependencies in Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
+      # Dependabotはデフォルトだとパッケージごとに個別PRを作るため、
+      # react だけ先にmergeされて react-dom と不整合になる瞬間が発生しうる。
+      # これを避けるために明示的にグループ化している。
       react:
         patterns:
           - "react"


### PR DESCRIPTION
## Summary
Updated the Dependabot configuration to group React-related dependencies together, enabling coordinated updates across the React ecosystem.

## Changes
- Added a new `groups` section under npm package updates in `.github/dependabot.yml`
- Created a "react" dependency group that includes:
  - `react`
  - `react-dom`
  - `@types/react`
  - `@types/react-dom`

## Details
This configuration ensures that React and its related type definitions are updated together in a single pull request, reducing the number of separate dependency updates and maintaining consistency across the React ecosystem packages.

https://claude.ai/code/session_01YDRjaiQnnF8n6mzkh3YWeV