### PR TITLE
chore(ci): remove debug push triggers from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
 on:
-  # TODO: push部分はデバッグ用。確認できたら削除する
-  push:
-    branches: [main]
-    # paths:
-    #   - "backend/**"
-    #   - "frontend/**"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,9 +1,6 @@
 name: Security
 
 on:
-  # TODO: push部分はデバッグ用。確認できたら削除する
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
デバッグ用に追加していた push トリガーを削除し、pull_request（と
security の schedule）のみで起動するように戻す。