### PR TITLE
Add push trigger to CI workflow for backend and frontend changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
+      - ".github/**"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "frontend/**"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,11 +1,6 @@
 name: Security
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "backend/**"
-      - "frontend/**"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,11 @@
 name: Security
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "frontend/**"
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
Updated the CI workflow to automatically run on push events to the main branch, in addition to the existing pull request trigger. This ensures continuous integration checks run immediately when code is pushed, not just when pull requests are created.

## Key Changes
- Added `push` trigger to CI workflow with `main` branch filter
- Configured path filters to run CI only when changes occur in `backend/**` or `frontend/**` directories
- Maintains existing pull request trigger with the same path filters for consistency

## Implementation Details
The workflow now triggers on both push and pull request events to the main branch, but only when changes are made to backend or frontend code. This prevents unnecessary CI runs for changes to other files (documentation, configuration, etc.) while ensuring code quality checks happen at the earliest point in the development process.

https://claude.ai/code/session_019Q7fgJqTFi1g8Ya1StPXpL