### PR TITLE
add product variants

### DIFF
--- a/backend/app/controllers/api/v1/cart_items_controller.rb
+++ b/backend/app/controllers/api/v1/cart_items_controller.rb
@@ -5,13 +5,15 @@ module Api
 
       def create
         cart = @current_user.cart || @current_user.create_cart!
-        product = Product.active.find(params[:product_id])
+        variant = ProductVariant.joins(:product)
+                                .where(products: { status: "active" })
+                                .find(params[:product_variant_id])
 
-        cart_item = cart.cart_items.find_by(product: product)
+        cart_item = cart.cart_items.find_by(product_variant: variant)
         if cart_item
           cart_item.increment!(:quantity)
         else
-          cart_item = cart.cart_items.create!(product: product, quantity: 1)
+          cart_item = cart.cart_items.create!(product_variant: variant, quantity: 1)
         end
 
         render json: cart_item, status: :created

--- a/backend/app/controllers/api/v1/carts_controller.rb
+++ b/backend/app/controllers/api/v1/carts_controller.rb
@@ -15,15 +15,20 @@ module Api
       private
 
       def cart_json(cart)
-        items = cart.cart_items.includes(:product).map do |item|
+        items = cart.cart_items.includes(product_variant: :product).map do |item|
+          variant = item.product_variant
+          product = variant.product
           {
             id: item.id,
-            product_id: item.product.id,
-            product_name: item.product.name,
-            unit_price: item.product.price,
+            product_id: product.id,
+            product_variant_id: variant.id,
+            product_name: product.name,
+            size: variant.size,
+            color: variant.color,
+            unit_price: variant.price,
             quantity: item.quantity,
-            subtotal: item.product.price * item.quantity,
-            product_deleted: item.product.deleted?
+            subtotal: variant.price * item.quantity,
+            product_deleted: product.deleted?
           }
         end
 

--- a/backend/app/controllers/api/v1/orders_controller.rb
+++ b/backend/app/controllers/api/v1/orders_controller.rb
@@ -21,7 +21,7 @@ module Api
           return render json: { error: "カートが空です" }, status: :unprocessable_entity
         end
 
-        active_items = cart.cart_items.includes(:product).select { |item| item.product.active? }
+        active_items = cart.cart_items.includes(product_variant: :product).select { |item| item.product.active? }
         if active_items.empty?
           return render json: { error: "注文可能な商品がありません" }, status: :unprocessable_entity
         end

--- a/backend/app/controllers/api/v1/orders_controller.rb
+++ b/backend/app/controllers/api/v1/orders_controller.rb
@@ -48,10 +48,13 @@ module Api
           )
 
           active_items.each do |cart_item|
+            variant = cart_item.product_variant
             order.order_items.create!(
-              product: cart_item.product,
-              product_name: cart_item.product.name,
-              unit_price: cart_item.product.price,
+              product_variant: variant,
+              product_name: variant.product.name,
+              size: variant.size,
+              color: variant.color,
+              unit_price: variant.price,
               quantity: cart_item.quantity
             )
           end
@@ -99,11 +102,14 @@ module Api
       end
 
       def order_detail_json(order)
-        items = order.order_items.includes(:product).map do |item|
+        items = order.order_items.includes(product_variant: :product).map do |item|
           {
             id: item.id,
-            product_id: item.product_id,
+            product_variant_id: item.product_variant_id,
+            product_id: item.product_variant&.product_id,
             product_name: item.product_name,
+            size: item.size,
+            color: item.color,
             unit_price: item.unit_price,
             quantity: item.quantity,
             subtotal: item.unit_price * item.quantity

--- a/backend/app/controllers/api/v1/products_controller.rb
+++ b/backend/app/controllers/api/v1/products_controller.rb
@@ -4,13 +4,13 @@ module Api
       before_action :authenticate_user!, only: [ :create, :update ]
 
       def index
-        products = Product.all
-        render json: products
+        products = Product.includes(:product_variants).all
+        render json: products.map { |product| product_summary_json(product) }
       end
 
       def show
-        product = Product.find(params[:id])
-        render json: product
+        product = Product.includes(:product_variants).find(params[:id])
+        render json: product_detail_json(product)
       rescue ActiveRecord::RecordNotFound
         render json: { error: "商品が見つかりません" }, status: :not_found
       end
@@ -36,19 +36,37 @@ module Api
           return render json: { error: "権限がありません" }, status: :forbidden
         end
 
-        if product.update(product_params)
-          render json: product
-        else
-          render json: { errors: product.errors.full_messages }, status: :unprocessable_entity
+        variants = variants_param
+        ActiveRecord::Base.transaction do
+          if variants
+            replace_variants(product, variants)
+            product.price = product.product_variants.reload.map(&:price).min
+          end
+          product.assign_attributes(product_attributes)
+          product.save!
         end
+
+        render json: product_detail_json(product.reload)
       rescue ActiveRecord::RecordNotFound
         render json: { error: "商品が見つかりません" }, status: :not_found
+      rescue ActiveRecord::RecordInvalid => e
+        render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
       end
 
       def create
-        product = @current_user.products.new(product_params)
+        variants = variants_param || []
+        if variants.empty?
+          return render json: { errors: [ "バリアントは1つ以上必要です" ] }, status: :unprocessable_entity
+        end
+
+        product = @current_user.products.new(product_attributes)
+        variants.each do |attrs|
+          product.product_variants.build(attrs.slice(:size, :color, :price))
+        end
+        product.price = variants.map { |v| v[:price].to_i }.min
+
         if product.save
-          render json: product, status: :created
+          render json: product_detail_json(product), status: :created
         else
           render json: { errors: product.errors.full_messages }, status: :unprocessable_entity
         end
@@ -56,8 +74,54 @@ module Api
 
       private
 
-      def product_params
-        params.permit(:name, :description, :price)
+      def product_attributes
+        params.permit(:name, :description).to_h.symbolize_keys.compact
+      end
+
+      def variants_param
+        return nil if params[:variants].nil?
+        Array(params[:variants]).map do |v|
+          permitted = v.respond_to?(:permit) ? v.permit(:id, :size, :color, :price) : v
+          permitted.to_h.symbolize_keys
+        end
+      end
+
+      def replace_variants(product, variants)
+        kept_ids = variants.filter_map { |v| v[:id]&.to_i }
+        product.product_variants.where.not(id: kept_ids).destroy_all
+
+        variants.each do |attrs|
+          if attrs[:id]
+            variant = product.product_variants.find(attrs[:id])
+            variant.update!(attrs.slice(:size, :color, :price))
+          else
+            product.product_variants.create!(attrs.slice(:size, :color, :price))
+          end
+        end
+      end
+
+      def product_summary_json(product)
+        prices = product.product_variants.map(&:price)
+        {
+          id: product.id,
+          name: product.name,
+          description: product.description,
+          min_price: prices.min,
+          max_price: prices.max,
+          user_id: product.user_id
+        }
+      end
+
+      def product_detail_json(product)
+        {
+          id: product.id,
+          name: product.name,
+          description: product.description,
+          user_id: product.user_id,
+          variants: product.product_variants.order(:id).map do |v|
+            { id: v.id, size: v.size, color: v.color, price: v.price }
+          end
+        }
       end
     end
   end

--- a/backend/app/controllers/api/v1/products_controller.rb
+++ b/backend/app/controllers/api/v1/products_controller.rb
@@ -38,10 +38,7 @@ module Api
 
         variants = variants_param
         ActiveRecord::Base.transaction do
-          if variants
-            replace_variants(product, variants)
-            product.price = product.product_variants.reload.map(&:price).min
-          end
+          replace_variants(product, variants) if variants
           product.assign_attributes(product_attributes)
           product.save!
         end
@@ -63,7 +60,6 @@ module Api
         variants.each do |attrs|
           product.product_variants.build(attrs.slice(:size, :color, :price))
         end
-        product.price = variants.map { |v| v[:price].to_i }.min
 
         if product.save
           render json: product_detail_json(product), status: :created

--- a/backend/app/models/cart_item.rb
+++ b/backend/app/models/cart_item.rb
@@ -1,6 +1,8 @@
 class CartItem < ApplicationRecord
   belongs_to :cart
-  belongs_to :product
+  belongs_to :product_variant
+
+  delegate :product, :product_id, to: :product_variant
 
   validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }
 end

--- a/backend/app/models/coupon.rb
+++ b/backend/app/models/coupon.rb
@@ -20,7 +20,7 @@ class Coupon < ApplicationRecord
     target_item = cart_items.find { |ci| ci.product_id == product_id }
     return 0 unless target_item
 
-    subtotal = target_item.product.price * target_item.quantity
+    subtotal = target_item.product_variant.price * target_item.quantity
     raw = case discount_type
     when "fixed"      then discount_value
     when "percentage" then subtotal * discount_value / 100

--- a/backend/app/models/order_item.rb
+++ b/backend/app/models/order_item.rb
@@ -1,6 +1,6 @@
 class OrderItem < ApplicationRecord
   belongs_to :order
-  belongs_to :product
+  belongs_to :product_variant, optional: true
 
   validates :product_name, presence: true
   validates :unit_price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }

--- a/backend/app/models/product.rb
+++ b/backend/app/models/product.rb
@@ -3,7 +3,7 @@ class Product < ApplicationRecord
   has_many :product_images, dependent: :destroy
   has_many :product_variants, dependent: :destroy
   has_many :cart_items, through: :product_variants
-  has_many :order_items, dependent: :nullify
+  has_many :order_items, through: :product_variants
   has_one :coupon, dependent: :destroy
 
   enum :status, { active: "active", deleted: "deleted" }

--- a/backend/app/models/product.rb
+++ b/backend/app/models/product.rb
@@ -2,7 +2,7 @@ class Product < ApplicationRecord
   belongs_to :user
   has_many :product_images, dependent: :destroy
   has_many :product_variants, dependent: :destroy
-  has_many :cart_items, dependent: :destroy
+  has_many :cart_items, through: :product_variants
   has_many :order_items, dependent: :nullify
   has_one :coupon, dependent: :destroy
 

--- a/backend/app/models/product.rb
+++ b/backend/app/models/product.rb
@@ -9,7 +9,6 @@ class Product < ApplicationRecord
   enum :status, { active: "active", deleted: "deleted" }
 
   validates :name, presence: true
-  validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validate :variants_pattern_consistency
 
   private

--- a/backend/app/models/product.rb
+++ b/backend/app/models/product.rb
@@ -1,6 +1,7 @@
 class Product < ApplicationRecord
   belongs_to :user
   has_many :product_images, dependent: :destroy
+  has_many :product_variants, dependent: :destroy
   has_many :cart_items, dependent: :destroy
   has_many :order_items, dependent: :nullify
   has_one :coupon, dependent: :destroy
@@ -9,4 +10,17 @@ class Product < ApplicationRecord
 
   validates :name, presence: true
   validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validate :variants_pattern_consistency
+
+  private
+
+  def variants_pattern_consistency
+    variants = product_variants.reject(&:marked_for_destruction?)
+    return if variants.empty?
+
+    patterns = variants.map { |v| [ v.size.present?, v.color.present? ] }.uniq
+    return if patterns.size == 1
+
+    errors.add(:product_variants, "のサイズ・カラーの有無は全バリアントで揃える必要があります")
+  end
 end

--- a/backend/app/models/product_variant.rb
+++ b/backend/app/models/product_variant.rb
@@ -1,6 +1,7 @@
 class ProductVariant < ApplicationRecord
   belongs_to :product
   has_many :cart_items, dependent: :destroy
+  has_many :order_items, dependent: :nullify
 
   validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/backend/app/models/product_variant.rb
+++ b/backend/app/models/product_variant.rb
@@ -1,0 +1,5 @@
+class ProductVariant < ApplicationRecord
+  belongs_to :product
+
+  validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+end

--- a/backend/app/models/product_variant.rb
+++ b/backend/app/models/product_variant.rb
@@ -1,5 +1,6 @@
 class ProductVariant < ApplicationRecord
   belongs_to :product
+  has_many :cart_items, dependent: :destroy
 
   validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/backend/db/migrate/20260522161000_create_product_variants.rb
+++ b/backend/db/migrate/20260522161000_create_product_variants.rb
@@ -1,0 +1,38 @@
+class CreateProductVariants < ActiveRecord::Migration[8.1]
+  def up
+    # バリアント機能導入に伴い、既存のショッピング系データを全削除
+    execute "DELETE FROM coupon_uses"
+    execute "DELETE FROM coupons"
+    execute "DELETE FROM order_items"
+    execute "DELETE FROM orders"
+    execute "DELETE FROM cart_items"
+    execute "DELETE FROM carts"
+    execute "DELETE FROM product_images"
+    execute "DELETE FROM products"
+
+    create_table :product_variants do |t|
+      t.references :product, null: false, foreign_key: true
+      t.string :size
+      t.string :color
+      t.integer :price, null: false
+      t.timestamps
+    end
+
+    add_index :product_variants, [ :product_id, :size, :color ],
+      unique: true, name: "idx_product_variants_size_and_color",
+      where: "size IS NOT NULL AND color IS NOT NULL"
+    add_index :product_variants, [ :product_id, :size ],
+      unique: true, name: "idx_product_variants_size_only",
+      where: "size IS NOT NULL AND color IS NULL"
+    add_index :product_variants, [ :product_id, :color ],
+      unique: true, name: "idx_product_variants_color_only",
+      where: "size IS NULL AND color IS NOT NULL"
+    add_index :product_variants, [ :product_id ],
+      unique: true, name: "idx_product_variants_no_axis",
+      where: "size IS NULL AND color IS NULL"
+  end
+
+  def down
+    drop_table :product_variants
+  end
+end

--- a/backend/db/migrate/20260522162000_change_cart_items_to_use_product_variants.rb
+++ b/backend/db/migrate/20260522162000_change_cart_items_to_use_product_variants.rb
@@ -1,0 +1,17 @@
+class ChangeCartItemsToUseProductVariants < ActiveRecord::Migration[8.1]
+  def up
+    execute "DELETE FROM cart_items"
+
+    remove_foreign_key :cart_items, :products
+    remove_index :cart_items, name: "index_cart_items_on_cart_id_and_product_id"
+    remove_index :cart_items, name: "index_cart_items_on_product_id"
+    remove_column :cart_items, :product_id
+
+    add_reference :cart_items, :product_variant, null: false, foreign_key: true
+    add_index :cart_items, [ :cart_id, :product_variant_id ], unique: true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/backend/db/migrate/20260522163000_change_order_items_to_use_product_variants.rb
+++ b/backend/db/migrate/20260522163000_change_order_items_to_use_product_variants.rb
@@ -1,0 +1,19 @@
+class ChangeOrderItemsToUseProductVariants < ActiveRecord::Migration[8.1]
+  def up
+    execute "DELETE FROM coupon_uses"
+    execute "DELETE FROM order_items"
+    execute "DELETE FROM orders"
+
+    remove_foreign_key :order_items, :products
+    remove_index :order_items, name: "index_order_items_on_product_id"
+    remove_column :order_items, :product_id
+
+    add_reference :order_items, :product_variant, null: true, foreign_key: true
+    add_column :order_items, :size, :string
+    add_column :order_items, :color, :string
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/backend/db/migrate/20260522164000_remove_price_from_products.rb
+++ b/backend/db/migrate/20260522164000_remove_price_from_products.rb
@@ -1,0 +1,5 @@
+class RemovePriceFromProducts < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :products, :price, :integer, null: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_22_163000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_22_164000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -118,7 +118,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_163000) do
     t.datetime "created_at", null: false
     t.text "description"
     t.string "name", null: false
-    t.integer "price", null: false
     t.string "status", default: "active", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_112220) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_22_161000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -98,6 +98,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_112220) do
     t.index ["product_id"], name: "index_product_images_on_product_id"
   end
 
+  create_table "product_variants", force: :cascade do |t|
+    t.string "color"
+    t.datetime "created_at", null: false
+    t.integer "price", null: false
+    t.bigint "product_id", null: false
+    t.string "size"
+    t.datetime "updated_at", null: false
+    t.index ["product_id", "color"], name: "idx_product_variants_color_only", unique: true, where: "((size IS NULL) AND (color IS NOT NULL))"
+    t.index ["product_id", "size", "color"], name: "idx_product_variants_size_and_color", unique: true, where: "((size IS NOT NULL) AND (color IS NOT NULL))"
+    t.index ["product_id", "size"], name: "idx_product_variants_size_only", unique: true, where: "((size IS NOT NULL) AND (color IS NULL))"
+    t.index ["product_id"], name: "idx_product_variants_no_axis", unique: true, where: "((size IS NULL) AND (color IS NULL))"
+    t.index ["product_id"], name: "index_product_variants_on_product_id"
+  end
+
   create_table "products", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
@@ -129,5 +143,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_112220) do
   add_foreign_key "order_items", "products"
   add_foreign_key "orders", "users"
   add_foreign_key "product_images", "products"
+  add_foreign_key "product_variants", "products"
   add_foreign_key "products", "users"
 end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_22_162000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_22_163000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -67,15 +67,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_162000) do
   end
 
   create_table "order_items", force: :cascade do |t|
+    t.string "color"
     t.datetime "created_at", null: false
     t.bigint "order_id", null: false
-    t.bigint "product_id", null: false
     t.string "product_name", null: false
+    t.bigint "product_variant_id"
     t.integer "quantity", null: false
+    t.string "size"
     t.integer "unit_price", null: false
     t.datetime "updated_at", null: false
     t.index ["order_id"], name: "index_order_items_on_order_id"
-    t.index ["product_id"], name: "index_order_items_on_product_id"
+    t.index ["product_variant_id"], name: "index_order_items_on_product_variant_id"
   end
 
   create_table "orders", force: :cascade do |t|
@@ -140,7 +142,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_162000) do
   add_foreign_key "coupon_uses", "users"
   add_foreign_key "coupons", "products"
   add_foreign_key "order_items", "orders"
-  add_foreign_key "order_items", "products"
+  add_foreign_key "order_items", "product_variants"
   add_foreign_key "orders", "users"
   add_foreign_key "product_images", "products"
   add_foreign_key "product_variants", "products"

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_22_161000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_22_162000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -26,12 +26,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_161000) do
   create_table "cart_items", force: :cascade do |t|
     t.bigint "cart_id", null: false
     t.datetime "created_at", null: false
-    t.bigint "product_id", null: false
+    t.bigint "product_variant_id", null: false
     t.integer "quantity", default: 1, null: false
     t.datetime "updated_at", null: false
-    t.index ["cart_id", "product_id"], name: "index_cart_items_on_cart_id_and_product_id", unique: true
+    t.index ["cart_id", "product_variant_id"], name: "index_cart_items_on_cart_id_and_product_variant_id", unique: true
     t.index ["cart_id"], name: "index_cart_items_on_cart_id"
-    t.index ["product_id"], name: "index_cart_items_on_product_id"
+    t.index ["product_variant_id"], name: "index_cart_items_on_product_variant_id"
   end
 
   create_table "carts", force: :cascade do |t|
@@ -133,7 +133,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_22_161000) do
   end
 
   add_foreign_key "cart_items", "carts"
-  add_foreign_key "cart_items", "products"
+  add_foreign_key "cart_items", "product_variants"
   add_foreign_key "carts", "users"
   add_foreign_key "coupon_uses", "coupons"
   add_foreign_key "coupon_uses", "orders"

--- a/backend/spec/requests/api/v1/cart_spec.rb
+++ b/backend/spec/requests/api/v1/cart_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::Cart", type: :request do
   let!(:user) { User.create!(name: "テストユーザー", email: "user@example.com", password: "password123") }
-  let!(:product) { Product.create!(name: "商品A", price: 1000, user: user) }
+  let!(:product) { Product.create!(name: "商品A", user: user) }
   let!(:variant) { product.product_variants.create!(size: "M", color: "red", price: 1000) }
   let(:headers) { { "Authorization" => "Bearer #{JwtHelper.encode(user_id: user.id)}" } }
 

--- a/backend/spec/requests/api/v1/cart_spec.rb
+++ b/backend/spec/requests/api/v1/cart_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Api::V1::Cart", type: :request do
   let!(:user) { User.create!(name: "テストユーザー", email: "user@example.com", password: "password123") }
   let!(:product) { Product.create!(name: "商品A", price: 1000, user: user) }
+  let!(:variant) { product.product_variants.create!(size: "M", color: "red", price: 1000) }
   let(:headers) { { "Authorization" => "Bearer #{JwtHelper.encode(user_id: user.id)}" } }
 
   def auth_header(u)
@@ -11,31 +12,31 @@ RSpec.describe "Api::V1::Cart", type: :request do
 
   describe "POST /api/v1/cart/items" do
     context "認証済みの場合" do
-      it "カートに商品を追加できる" do
-        post "/api/v1/cart/items", params: { product_id: product.id }, headers: headers, as: :json
+      it "カートにバリアントを追加できる" do
+        post "/api/v1/cart/items", params: { product_variant_id: variant.id }, headers: headers, as: :json
 
         expect(response).to have_http_status(:created)
         expect(user.cart.cart_items.count).to eq(1)
         expect(user.cart.cart_items.first.quantity).to eq(1)
       end
 
-      it "同じ商品を再度追加すると数量が+1される" do
-        post "/api/v1/cart/items", params: { product_id: product.id }, headers: headers, as: :json
-        post "/api/v1/cart/items", params: { product_id: product.id }, headers: headers, as: :json
+      it "同じバリアントを再度追加すると数量が+1される" do
+        post "/api/v1/cart/items", params: { product_variant_id: variant.id }, headers: headers, as: :json
+        post "/api/v1/cart/items", params: { product_variant_id: variant.id }, headers: headers, as: :json
 
         expect(user.cart.cart_items.count).to eq(1)
         expect(user.cart.cart_items.first.quantity).to eq(2)
       end
 
-      it "削除済み商品は追加できない" do
+      it "削除済み商品のバリアントは追加できない" do
         product.deleted!
-        post "/api/v1/cart/items", params: { product_id: product.id }, headers: headers, as: :json
+        post "/api/v1/cart/items", params: { product_variant_id: variant.id }, headers: headers, as: :json
 
         expect(response).to have_http_status(:not_found)
       end
 
-      it "存在しない商品IDの場合404を返す" do
-        post "/api/v1/cart/items", params: { product_id: 99999 }, headers: headers, as: :json
+      it "存在しないバリアントIDの場合404を返す" do
+        post "/api/v1/cart/items", params: { product_variant_id: 99999 }, headers: headers, as: :json
 
         expect(response).to have_http_status(:not_found)
       end
@@ -43,7 +44,7 @@ RSpec.describe "Api::V1::Cart", type: :request do
 
     context "未認証の場合" do
       it "401を返す" do
-        post "/api/v1/cart/items", params: { product_id: product.id }, as: :json
+        post "/api/v1/cart/items", params: { product_variant_id: variant.id }, as: :json
 
         expect(response).to have_http_status(:unauthorized)
       end
@@ -54,10 +55,10 @@ RSpec.describe "Api::V1::Cart", type: :request do
     context "カートにアイテムがある場合" do
       before do
         cart = user.create_cart!
-        cart.cart_items.create!(product: product, quantity: 2)
+        cart.cart_items.create!(product_variant: variant, quantity: 2)
       end
 
-      it "カート内容を返す" do
+      it "カート内容（バリアント情報含む）を返す" do
         get "/api/v1/cart", headers: headers, as: :json
 
         expect(response).to have_http_status(:ok)
@@ -66,6 +67,8 @@ RSpec.describe "Api::V1::Cart", type: :request do
         expect(body["items"].length).to eq(1)
         expect(body["items"].first).to include(
           "product_name" => "商品A",
+          "size" => "M",
+          "color" => "red",
           "unit_price" => 1000,
           "quantity" => 2,
           "subtotal" => 2000
@@ -96,7 +99,7 @@ RSpec.describe "Api::V1::Cart", type: :request do
 
   describe "PATCH /api/v1/cart/items/:id" do
     let!(:cart) { user.create_cart! }
-    let!(:cart_item) { cart.cart_items.create!(product: product, quantity: 2) }
+    let!(:cart_item) { cart.cart_items.create!(product_variant: variant, quantity: 2) }
 
     context "認証済みの場合" do
       it "数量を変更できる" do
@@ -123,7 +126,7 @@ RSpec.describe "Api::V1::Cart", type: :request do
 
   describe "DELETE /api/v1/cart/items/:id" do
     let!(:cart) { user.create_cart! }
-    let!(:cart_item) { cart.cart_items.create!(product: product, quantity: 1) }
+    let!(:cart_item) { cart.cart_items.create!(product_variant: variant, quantity: 1) }
 
     context "認証済みの場合" do
       it "カートからアイテムを削除できる" do

--- a/backend/spec/requests/api/v1/coupons_spec.rb
+++ b/backend/spec/requests/api/v1/coupons_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Api::V1::Coupons", type: :request do
   let!(:seller) { User.create!(name: "出品者", email: "seller@example.com", password: "password123") }
   let!(:other_user) { User.create!(name: "他ユーザー", email: "other@example.com", password: "password123") }
-  let!(:product) { Product.create!(name: "商品A", price: 1000, user: seller) }
+  let!(:product) { Product.create!(name: "商品A", user: seller) }
 
   def auth_header(user)
     { "Authorization" => "Bearer #{JwtHelper.encode(user_id: user.id)}" }

--- a/backend/spec/requests/api/v1/orders_spec.rb
+++ b/backend/spec/requests/api/v1/orders_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Api::V1::Orders", type: :request do
   let!(:user) { User.create!(name: "テストユーザー", email: "user@example.com", password: "password123") }
   let!(:product) { Product.create!(name: "商品A", price: 1000, user: user) }
+  let!(:variant) { product.product_variants.create!(price: 1000) }
   let!(:product2) { Product.create!(name: "商品B", price: 2000, user: user) }
+  let!(:variant2) { product2.product_variants.create!(price: 2000) }
   let(:headers) { { "Authorization" => "Bearer #{JwtHelper.encode(user_id: user.id)}" } }
 
   def auth_header(u)
@@ -14,8 +16,8 @@ RSpec.describe "Api::V1::Orders", type: :request do
     context "カートにアイテムがある場合" do
       before do
         cart = user.create_cart!
-        cart.cart_items.create!(product: product, quantity: 2)
-        cart.cart_items.create!(product: product2, quantity: 1)
+        cart.cart_items.create!(product_variant: variant, quantity: 2)
+        cart.cart_items.create!(product_variant: variant2, quantity: 1)
       end
 
       it "注文が作成され、カートが空になる" do
@@ -54,7 +56,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
       before do
         product.deleted!
         cart = user.create_cart!
-        cart.cart_items.create!(product: product, quantity: 1)
+        cart.cart_items.create!(product_variant: variant, quantity: 1)
       end
 
       it "422を返す" do
@@ -75,6 +77,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
     context "クーポンを適用する場合" do
       let!(:seller) { User.create!(name: "出品者", email: "seller-coupon@example.com", password: "password123") }
       let!(:coupon_product) { Product.create!(name: "対象商品", price: 1000, user: seller) }
+      let!(:coupon_variant) { coupon_product.product_variants.create!(price: 1000) }
 
       context "固定額クーポン" do
         let!(:coupon) do
@@ -83,7 +86,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
 
         before do
           cart = user.create_cart!
-          cart.cart_items.create!(product: coupon_product, quantity: 1)
+          cart.cart_items.create!(product_variant: coupon_variant, quantity: 1)
         end
 
         it "割引額が適用され coupon_use が記録される" do
@@ -136,7 +139,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
 
         before do
           cart = user.create_cart!
-          cart.cart_items.create!(product: coupon_product, quantity: 1)
+          cart.cart_items.create!(product_variant: coupon_variant, quantity: 1)
         end
 
         it "商品金額に対して割引率が適用される" do
@@ -157,7 +160,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
       context "クーポンが無効な場合" do
         before do
           cart = user.create_cart!
-          cart.cart_items.create!(product: coupon_product, quantity: 1)
+          cart.cart_items.create!(product_variant: coupon_variant, quantity: 1)
         end
 
         it "存在しないコードならエラー" do
@@ -198,7 +201,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
 
         before do
           cart = user.create_cart!
-          cart.cart_items.create!(product: product, quantity: 1)
+          cart.cart_items.create!(product_variant: variant, quantity: 1)
         end
 
         it "エラーになる" do
@@ -213,7 +216,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
       context "クーポンコードなしの場合" do
         before do
           cart = user.create_cart!
-          cart.cart_items.create!(product: coupon_product, quantity: 1)
+          cart.cart_items.create!(product_variant: coupon_variant, quantity: 1)
         end
 
         it "通常通り注文できる（discount_amount は 0）" do
@@ -260,6 +263,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
     context "クーポンが適用された注文の場合" do
       let!(:seller) { User.create!(name: "出品者", email: "seller-cancel@example.com", password: "password123") }
       let!(:coupon_product) { Product.create!(name: "対象商品", price: 1000, user: seller) }
+      let!(:coupon_variant) { coupon_product.product_variants.create!(price: 1000) }
       let!(:coupon) do
         Coupon.create!(product: coupon_product, code: "CANCELME12", discount_type: "fixed", discount_value: 300, expires_at: 1.month.from_now)
       end
@@ -280,7 +284,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
         patch "/api/v1/orders/#{coupon_order.id}/cancel", headers: headers, as: :json
 
         cart = user.cart || user.create_cart!
-        cart.cart_items.create!(product: coupon_product, quantity: 1)
+        cart.cart_items.create!(product_variant: coupon_variant, quantity: 1)
 
         post "/api/v1/orders", params: { coupon_code: "CANCELME12" }, headers: headers, as: :json
         expect(response).to have_http_status(:created)

--- a/backend/spec/requests/api/v1/orders_spec.rb
+++ b/backend/spec/requests/api/v1/orders_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
   describe "PATCH /api/v1/orders/:id/cancel" do
     let!(:order) do
       order = user.orders.create!(order_number: SecureRandom.uuid, status: :confirmed)
-      order.order_items.create!(product: product, product_name: "商品A", unit_price: 1000, quantity: 1)
+      order.order_items.create!(product_variant: variant, product_name: "商品A", unit_price: 1000, quantity: 1)
       order
     end
 
@@ -269,7 +269,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
       end
       let!(:coupon_order) do
         o = user.orders.create!(order_number: SecureRandom.uuid, status: :confirmed, discount_amount: 300)
-        o.order_items.create!(product: coupon_product, product_name: "対象商品", unit_price: 1000, quantity: 1)
+        o.order_items.create!(product_variant: coupon_variant, product_name: "対象商品", unit_price: 1000, quantity: 1)
         CouponUse.create!(coupon: coupon, user: user, order: o, status: :used)
         o
       end
@@ -296,7 +296,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
     before do
       2.times do |i|
         order = user.orders.create!(order_number: SecureRandom.uuid, status: :confirmed)
-        order.order_items.create!(product: product, product_name: "商品A", unit_price: 1000, quantity: i + 1)
+        order.order_items.create!(product_variant: variant, product_name: "商品A", unit_price: 1000, quantity: i + 1)
       end
     end
 
@@ -312,7 +312,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
 
     it "割引が適用された注文は total が割引後の金額になる" do
       discounted = user.orders.create!(order_number: SecureRandom.uuid, status: :confirmed, discount_amount: 150)
-      discounted.order_items.create!(product: product, product_name: "商品A", unit_price: 1000, quantity: 1)
+      discounted.order_items.create!(product_variant: variant, product_name: "商品A", unit_price: 1000, quantity: 1)
 
       get "/api/v1/orders", headers: headers, as: :json
 
@@ -332,7 +332,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
   describe "GET /api/v1/orders/:id" do
     let!(:order) do
       order = user.orders.create!(order_number: SecureRandom.uuid, status: :confirmed)
-      order.order_items.create!(product: product, product_name: "商品A", unit_price: 1000, quantity: 2)
+      order.order_items.create!(product_variant: variant, product_name: "商品A", unit_price: 1000, quantity: 2)
       order
     end
 
@@ -351,7 +351,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
     context "割引が適用された注文の場合" do
       let!(:discounted_order) do
         o = user.orders.create!(order_number: SecureRandom.uuid, status: :confirmed, discount_amount: 300)
-        o.order_items.create!(product: product, product_name: "商品A", unit_price: 1000, quantity: 1)
+        o.order_items.create!(product_variant: variant, product_name: "商品A", unit_price: 1000, quantity: 1)
         o
       end
 

--- a/backend/spec/requests/api/v1/orders_spec.rb
+++ b/backend/spec/requests/api/v1/orders_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::Orders", type: :request do
   let!(:user) { User.create!(name: "テストユーザー", email: "user@example.com", password: "password123") }
-  let!(:product) { Product.create!(name: "商品A", price: 1000, user: user) }
+  let!(:product) { Product.create!(name: "商品A", user: user) }
   let!(:variant) { product.product_variants.create!(price: 1000) }
-  let!(:product2) { Product.create!(name: "商品B", price: 2000, user: user) }
+  let!(:product2) { Product.create!(name: "商品B", user: user) }
   let!(:variant2) { product2.product_variants.create!(price: 2000) }
   let(:headers) { { "Authorization" => "Bearer #{JwtHelper.encode(user_id: user.id)}" } }
 
@@ -76,7 +76,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
 
     context "クーポンを適用する場合" do
       let!(:seller) { User.create!(name: "出品者", email: "seller-coupon@example.com", password: "password123") }
-      let!(:coupon_product) { Product.create!(name: "対象商品", price: 1000, user: seller) }
+      let!(:coupon_product) { Product.create!(name: "対象商品", user: seller) }
       let!(:coupon_variant) { coupon_product.product_variants.create!(price: 1000) }
 
       context "固定額クーポン" do
@@ -262,7 +262,7 @@ RSpec.describe "Api::V1::Orders", type: :request do
 
     context "クーポンが適用された注文の場合" do
       let!(:seller) { User.create!(name: "出品者", email: "seller-cancel@example.com", password: "password123") }
-      let!(:coupon_product) { Product.create!(name: "対象商品", price: 1000, user: seller) }
+      let!(:coupon_product) { Product.create!(name: "対象商品", user: seller) }
       let!(:coupon_variant) { coupon_product.product_variants.create!(price: 1000) }
       let!(:coupon) do
         Coupon.create!(product: coupon_product, code: "CANCELME12", discount_type: "fixed", discount_value: 300, expires_at: 1.month.from_now)

--- a/backend/spec/requests/api/v1/products_spec.rb
+++ b/backend/spec/requests/api/v1/products_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Api::V1::Products", type: :request do
 
   describe "GET /api/v1/products/:id" do
     let!(:product) do
-      product = Product.create!(name: "商品A", description: "説明A", price: 1000, user: user)
+      product = Product.create!(name: "商品A", description: "説明A", user: user)
       product.product_variants.create!(size: "M", color: "red", price: 1000)
       product.product_variants.create!(size: "L", color: "red", price: 1500)
       product
@@ -41,7 +41,7 @@ RSpec.describe "Api::V1::Products", type: :request do
   describe "DELETE /api/v1/products/:id" do
     let!(:owner) { User.create!(name: "出品者", email: "owner@example.com", password: "password123") }
     let!(:other) { User.create!(name: "他ユーザー", email: "other@example.com", password: "password123") }
-    let!(:product) { Product.create!(name: "削除対象商品", description: "説明", price: 1000, user: owner) }
+    let!(:product) { Product.create!(name: "削除対象商品", description: "説明", user: owner) }
 
     context "出品者本人の場合" do
       it "200 を返し商品が削除される" do
@@ -205,7 +205,7 @@ RSpec.describe "Api::V1::Products", type: :request do
 
   describe "PATCH /api/v1/products/:id" do
     let!(:product) do
-      p = Product.create!(name: "商品A", description: "説明A", price: 1000, user: user)
+      p = Product.create!(name: "商品A", description: "説明A", user: user)
       p.product_variants.create!(size: "M", color: "red", price: 1000)
       p.product_variants.create!(size: "L", color: "red", price: 1500)
       p
@@ -247,11 +247,11 @@ RSpec.describe "Api::V1::Products", type: :request do
   describe "GET /api/v1/products" do
     context "商品が存在する場合" do
       before do
-        a = Product.create!(name: "商品A", description: "説明A", price: 1000, user: user)
+        a = Product.create!(name: "商品A", description: "説明A", user: user)
         a.product_variants.create!(size: "M", price: 1000)
         a.product_variants.create!(size: "L", price: 1500)
 
-        b = Product.create!(name: "商品B", description: nil, price: 2000, user: user)
+        b = Product.create!(name: "商品B", description: nil, user: user)
         b.product_variants.create!(price: 2000)
       end
 

--- a/backend/spec/requests/api/v1/products_spec.rb
+++ b/backend/spec/requests/api/v1/products_spec.rb
@@ -3,17 +3,29 @@ require "rails_helper"
 RSpec.describe "Api::V1::Products", type: :request do
   let!(:user) { User.create!(name: "販売者", email: "seller@example.com", password: "password123") }
 
+  def auth_header(user)
+    token = JwtHelper.encode(user_id: user.id)
+    { "Authorization" => "Bearer #{token}" }
+  end
+
   describe "GET /api/v1/products/:id" do
-    let!(:product) { Product.create!(name: "商品A", description: "説明A", price: 1000, user: user) }
+    let!(:product) do
+      product = Product.create!(name: "商品A", description: "説明A", price: 1000, user: user)
+      product.product_variants.create!(size: "M", color: "red", price: 1000)
+      product.product_variants.create!(size: "L", color: "red", price: 1500)
+      product
+    end
 
     context "商品が存在する場合" do
-      it "200 と商品情報を返す" do
+      it "200 と商品情報・バリアント一覧を返す" do
         get "/api/v1/products/#{product.id}", as: :json
 
         expect(response).to have_http_status(:ok)
 
         body = JSON.parse(response.body)
-        expect(body).to include("id" => product.id, "name" => "商品A", "description" => "説明A", "price" => 1000)
+        expect(body).to include("id" => product.id, "name" => "商品A", "description" => "説明A")
+        expect(body["variants"].length).to eq(2)
+        expect(body["variants"].first).to include("size" => "M", "color" => "red", "price" => 1000)
       end
     end
 
@@ -31,13 +43,8 @@ RSpec.describe "Api::V1::Products", type: :request do
     let!(:other) { User.create!(name: "他ユーザー", email: "other@example.com", password: "password123") }
     let!(:product) { Product.create!(name: "削除対象商品", description: "説明", price: 1000, user: owner) }
 
-    def auth_header(user)
-      token = JwtHelper.encode(user_id: user.id)
-      { "Authorization" => "Bearer #{token}" }
-    end
-
     context "出品者本人の場合" do
-      it "204 を返し商品が削除される" do
+      it "200 を返し商品が削除される" do
         delete "/api/v1/products/#{product.id}", headers: auth_header(owner), as: :json
 
         expect(response).to have_http_status(:ok)
@@ -72,39 +79,112 @@ RSpec.describe "Api::V1::Products", type: :request do
   end
 
   describe "POST /api/v1/products" do
-    let(:headers) { { "Authorization" => "Bearer #{JwtHelper.encode({ user_id: user.id })}" } }
+    let(:headers) { auth_header(user) }
 
     context "認証済みの場合" do
       context "正常なパラメータの場合" do
-        it "201 と作成した商品を返す" do
-          post "/api/v1/products", params: { name: "新商品", price: 1500 }, headers: headers, as: :json
+        it "201 とバリアント付きの商品を返す" do
+          post "/api/v1/products",
+               params: {
+                 name: "新商品",
+                 variants: [
+                   { size: "M", color: "red", price: 1000 },
+                   { size: "L", color: "red", price: 1500 }
+                 ]
+               },
+               headers: headers,
+               as: :json
 
           expect(response).to have_http_status(:created)
 
           body = JSON.parse(response.body)
-          expect(body).to include("name" => "新商品", "price" => 1500, "user_id" => user.id)
+          expect(body).to include("name" => "新商品", "user_id" => user.id)
+          expect(body["variants"].length).to eq(2)
+          expect(body["variants"].map { |v| v["price"] }).to contain_exactly(1000, 1500)
+        end
+
+        it "バリアントが1つ（軸なし）でも作成できる" do
+          post "/api/v1/products",
+               params: { name: "単一商品", variants: [ { price: 500 } ] },
+               headers: headers,
+               as: :json
+
+          expect(response).to have_http_status(:created)
+          body = JSON.parse(response.body)
+          expect(body["variants"].length).to eq(1)
+          expect(body["variants"].first).to include("size" => nil, "color" => nil, "price" => 500)
         end
 
         it "description なしでも作成できる" do
-          post "/api/v1/products", params: { name: "説明なし商品", price: 500 }, headers: headers, as: :json
+          post "/api/v1/products",
+               params: { name: "説明なし商品", variants: [ { price: 500 } ] },
+               headers: headers,
+               as: :json
 
           expect(response).to have_http_status(:created)
           expect(JSON.parse(response.body)["description"]).to be_nil
         end
       end
 
-      context "name が空の場合" do
+      context "variants が空の場合" do
         it "422 を返す" do
-          post "/api/v1/products", params: { name: "", price: 1500 }, headers: headers, as: :json
+          post "/api/v1/products",
+               params: { name: "新商品", variants: [] },
+               headers: headers,
+               as: :json
 
           expect(response).to have_http_status(:unprocessable_entity)
           expect(JSON.parse(response.body)).to have_key("errors")
         end
       end
 
-      context "price が負の値の場合" do
+      context "variants パラメータが無い場合" do
         it "422 を返す" do
-          post "/api/v1/products", params: { name: "商品", price: -1 }, headers: headers, as: :json
+          post "/api/v1/products",
+               params: { name: "新商品" },
+               headers: headers,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context "name が空の場合" do
+        it "422 を返す" do
+          post "/api/v1/products",
+               params: { name: "", variants: [ { price: 1000 } ] },
+               headers: headers,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(JSON.parse(response.body)).to have_key("errors")
+        end
+      end
+
+      context "variants の price が負の値の場合" do
+        it "422 を返す" do
+          post "/api/v1/products",
+               params: { name: "商品", variants: [ { price: -1 } ] },
+               headers: headers,
+               as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(JSON.parse(response.body)).to have_key("errors")
+        end
+      end
+
+      context "バリアントのパターンが混在している場合" do
+        it "422 を返す" do
+          post "/api/v1/products",
+               params: {
+                 name: "混在商品",
+                 variants: [
+                   { size: "M", price: 1000 },
+                   { color: "red", price: 1000 }
+                 ]
+               },
+               headers: headers,
+               as: :json
 
           expect(response).to have_http_status(:unprocessable_entity)
           expect(JSON.parse(response.body)).to have_key("errors")
@@ -114,28 +194,80 @@ RSpec.describe "Api::V1::Products", type: :request do
 
     context "未認証の場合" do
       it "401 を返す" do
-        post "/api/v1/products", params: { name: "新商品", price: 1500 }, as: :json
+        post "/api/v1/products",
+             params: { name: "新商品", variants: [ { price: 1000 } ] },
+             as: :json
 
         expect(response).to have_http_status(:unauthorized)
       end
     end
   end
 
+  describe "PATCH /api/v1/products/:id" do
+    let!(:product) do
+      p = Product.create!(name: "商品A", description: "説明A", price: 1000, user: user)
+      p.product_variants.create!(size: "M", color: "red", price: 1000)
+      p.product_variants.create!(size: "L", color: "red", price: 1500)
+      p
+    end
+    let(:headers) { auth_header(user) }
+
+    it "バリアントを置き換える（含まれないものは削除）" do
+      remaining_variant = product.product_variants.find_by(size: "M")
+
+      patch "/api/v1/products/#{product.id}",
+            params: {
+              variants: [
+                { id: remaining_variant.id, size: "M", color: "red", price: 1200 },
+                { size: "XL", color: "red", price: 2000 }
+              ]
+            },
+            headers: headers,
+            as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["variants"].length).to eq(2)
+      expect(body["variants"].map { |v| v["size"] }).to contain_exactly("M", "XL")
+      expect(product.reload.product_variants.find(remaining_variant.id).price).to eq(1200)
+    end
+
+    it "他人の商品は編集できない" do
+      other = User.create!(name: "他", email: "other@example.com", password: "password123")
+
+      patch "/api/v1/products/#{product.id}",
+            params: { name: "改ざん" },
+            headers: auth_header(other),
+            as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe "GET /api/v1/products" do
     context "商品が存在する場合" do
       before do
-        Product.create!(name: "商品A", description: "説明A", price: 1000, user: user)
-        Product.create!(name: "商品B", description: nil, price: 2000, user: user)
+        a = Product.create!(name: "商品A", description: "説明A", price: 1000, user: user)
+        a.product_variants.create!(size: "M", price: 1000)
+        a.product_variants.create!(size: "L", price: 1500)
+
+        b = Product.create!(name: "商品B", description: nil, price: 2000, user: user)
+        b.product_variants.create!(price: 2000)
       end
 
-      it "200 と商品一覧を返す" do
+      it "200 と価格レンジ付きの商品一覧を返す" do
         get "/api/v1/products", as: :json
 
         expect(response).to have_http_status(:ok)
 
         body = JSON.parse(response.body)
         expect(body.length).to eq(2)
-        expect(body.first).to include("id", "name", "description", "price", "user_id")
+
+        product_a = body.find { |p| p["name"] == "商品A" }
+        expect(product_a).to include("min_price" => 1000, "max_price" => 1500)
+
+        product_b = body.find { |p| p["name"] == "商品B" }
+        expect(product_b).to include("min_price" => 2000, "max_price" => 2000)
       end
     end
 

--- a/frontend/app/cart/AddToCartButton.tsx
+++ b/frontend/app/cart/AddToCartButton.tsx
@@ -4,7 +4,13 @@ import { useState } from "react";
 import { useSession } from "next-auth/react";
 import { addToCart } from "./actions";
 
-export default function AddToCartButton({ productId }: { productId: number }) {
+export default function AddToCartButton({
+  productVariantId,
+  label = "カートに追加",
+}: {
+  productVariantId: number;
+  label?: string;
+}) {
   const { data: session } = useSession();
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
@@ -15,7 +21,7 @@ export default function AddToCartButton({ productId }: { productId: number }) {
     setLoading(true);
     setMessage(null);
     try {
-      await addToCart(productId);
+      await addToCart(productVariantId);
       setMessage("カートに追加しました");
       setTimeout(() => setMessage(null), 2000);
     } catch (e) {
@@ -27,7 +33,7 @@ export default function AddToCartButton({ productId }: { productId: number }) {
   return (
     <span>
       <button onClick={handleClick} disabled={loading} style={{ marginLeft: "0.5rem" }}>
-        {loading ? "追加中..." : "カートに追加"}
+        {loading ? "追加中..." : label}
       </button>
       {message && <span style={{ marginLeft: "0.5rem", color: message.includes("エラー") ? "red" : "green" }}>{message}</span>}
     </span>

--- a/frontend/app/cart/CartItemRow.tsx
+++ b/frontend/app/cart/CartItemRow.tsx
@@ -6,12 +6,20 @@ import { updateCartItemQuantity, removeCartItem } from "./actions";
 type CartItem = {
   id: number;
   product_id: number;
+  product_variant_id: number;
   product_name: string;
+  size: string | null;
+  color: string | null;
   unit_price: number;
   quantity: number;
   subtotal: number;
   product_deleted: boolean;
 };
+
+function variantLabel(item: CartItem): string {
+  const parts = [item.size, item.color].filter(Boolean);
+  return parts.length > 0 ? `（${parts.join(" / ")}）` : "";
+}
 
 export default function CartItemRow({ item }: { item: CartItem }) {
   const [loading, setLoading] = useState(false);
@@ -41,7 +49,8 @@ export default function CartItemRow({ item }: { item: CartItem }) {
     return (
       <tr style={{ color: "#999" }}>
         <td style={{ padding: "0.5rem" }}>
-          {item.product_name}（この商品は削除されました）
+          {item.product_name}
+          {variantLabel(item)}（この商品は削除されました）
         </td>
         <td colSpan={3}></td>
         <td style={{ padding: "0.5rem" }}>
@@ -53,7 +62,10 @@ export default function CartItemRow({ item }: { item: CartItem }) {
 
   return (
     <tr>
-      <td style={{ padding: "0.5rem" }}>{item.product_name}</td>
+      <td style={{ padding: "0.5rem" }}>
+        {item.product_name}
+        {variantLabel(item) && <span style={{ color: "#666", marginLeft: "0.25rem" }}>{variantLabel(item)}</span>}
+      </td>
       <td style={{ textAlign: "right", padding: "0.5rem" }}>{item.unit_price}円</td>
       <td style={{ textAlign: "center", padding: "0.5rem" }}>
         <button onClick={() => handleQuantityChange(-1)} disabled={loading || item.quantity <= 1}>−</button>

--- a/frontend/app/cart/actions.ts
+++ b/frontend/app/cart/actions.ts
@@ -3,10 +3,10 @@
 import { apiFetch } from "@/lib/api";
 import { revalidatePath } from "next/cache";
 
-export async function addToCart(productId: number) {
+export async function addToCart(productVariantId: number) {
   const res = await apiFetch("/api/v1/cart/items", {
     method: "POST",
-    body: JSON.stringify({ product_id: productId }),
+    body: JSON.stringify({ product_variant_id: productVariantId }),
   });
   if (!res.ok) {
     const data = await res.json();

--- a/frontend/app/cart/page.tsx
+++ b/frontend/app/cart/page.tsx
@@ -7,7 +7,10 @@ import PlaceOrderButton from "./PlaceOrderButton";
 type CartItem = {
   id: number;
   product_id: number;
+  product_variant_id: number;
   product_name: string;
+  size: string | null;
+  color: string | null;
   unit_price: number;
   quantity: number;
   subtotal: number;

--- a/frontend/app/orders/[id]/page.tsx
+++ b/frontend/app/orders/[id]/page.tsx
@@ -6,12 +6,20 @@ import CancelOrderButton from "./CancelOrderButton";
 
 type OrderItem = {
   id: number;
-  product_id: number;
+  product_id: number | null;
+  product_variant_id: number | null;
   product_name: string;
+  size: string | null;
+  color: string | null;
   unit_price: number;
   quantity: number;
   subtotal: number;
 };
+
+function variantLabel(item: OrderItem): string {
+  const parts = [item.size, item.color].filter(Boolean);
+  return parts.length > 0 ? `（${parts.join(" / ")}）` : "";
+}
 
 type OrderDetail = {
   id: number;
@@ -67,9 +75,16 @@ export default async function OrderDetailPage({ params }: { params: Promise<{ id
           {order.items.map((item) => (
             <tr key={item.id}>
               <td style={{ padding: "0.5rem" }}>
-                <Link href={`/products/${item.product_id}`} style={{ color: "blue", textDecoration: "underline" }}>
-                  {item.product_name}
-                </Link>
+                {item.product_id ? (
+                  <Link href={`/products/${item.product_id}`} style={{ color: "blue", textDecoration: "underline" }}>
+                    {item.product_name}
+                  </Link>
+                ) : (
+                  item.product_name
+                )}
+                {variantLabel(item) && (
+                  <span style={{ color: "#666", marginLeft: "0.25rem" }}>{variantLabel(item)}</span>
+                )}
               </td>
               <td style={{ textAlign: "right", padding: "0.5rem" }}>{item.unit_price}円</td>
               <td style={{ textAlign: "center", padding: "0.5rem" }}>{item.quantity}</td>

--- a/frontend/app/products/[id]/edit/EditForm.tsx
+++ b/frontend/app/products/[id]/edit/EditForm.tsx
@@ -3,26 +3,63 @@
 import { useState, FormEvent } from "react";
 import { updateProduct } from "./actions";
 
+type Variant = {
+  id: number;
+  size: string | null;
+  color: string | null;
+  price: number;
+};
+
+type VariantInput = { id: number | null; size: string; color: string; price: string };
+
 type Props = {
   product: {
     id: number;
     name: string;
     description: string | null;
-    price: number;
+    variants: Variant[];
   };
 };
 
 export default function EditForm({ product }: Props) {
   const [name, setName] = useState(product.name);
   const [description, setDescription] = useState(product.description ?? "");
-  const [price, setPrice] = useState(String(product.price));
+  const [variants, setVariants] = useState<VariantInput[]>(
+    product.variants.map((v) => ({
+      id: v.id,
+      size: v.size ?? "",
+      color: v.color ?? "",
+      price: String(v.price),
+    }))
+  );
   const [error, setError] = useState<string | null>(null);
+
+  function updateVariant(index: number, key: keyof Omit<VariantInput, "id">, value: string) {
+    setVariants((prev) => prev.map((v, i) => (i === index ? { ...v, [key]: value } : v)));
+  }
+
+  function addVariant() {
+    setVariants((prev) => [...prev, { id: null, size: "", color: "", price: "" }]);
+  }
+
+  function removeVariant(index: number) {
+    setVariants((prev) => prev.filter((_, i) => i !== index));
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setError(null);
     try {
-      await updateProduct(product.id, { name, description: description || null, price: Number(price) });
+      await updateProduct(product.id, {
+        name,
+        description: description || null,
+        variants: variants.map((v) => ({
+          id: v.id,
+          size: v.size || null,
+          color: v.color || null,
+          price: Number(v.price),
+        })),
+      });
     } catch (e) {
       setError(e instanceof Error ? e.message : "商品の更新に失敗しました");
     }
@@ -52,21 +89,51 @@ export default function EditForm({ product }: Props) {
           style={{ width: "100%", marginBottom: "1rem" }}
         />
       </div>
-      <div>
-        <label htmlFor="price">価格（円）</label>
-        <br />
-        <input
-          id="price"
-          type="number"
-          min="0"
-          value={price}
-          onChange={(e) => setPrice(e.target.value)}
-          required
-          style={{ width: "100%", marginBottom: "1rem" }}
-        />
-      </div>
+
+      <h2 style={{ fontSize: "1.1rem" }}>バリアント</h2>
+      <p style={{ fontSize: "0.85rem", color: "#666" }}>
+        ここから外したバリアントは削除されます。サイズ・カラーの有無は全バリアントで揃える必要があります。
+      </p>
+      {variants.map((v, i) => (
+        <div key={i} style={{ display: "flex", gap: "0.5rem", marginBottom: "0.5rem", alignItems: "center" }}>
+          <input
+            type="text"
+            placeholder="サイズ（任意）"
+            value={v.size}
+            onChange={(e) => updateVariant(i, "size", e.target.value)}
+            style={{ flex: 1 }}
+          />
+          <input
+            type="text"
+            placeholder="カラー（任意）"
+            value={v.color}
+            onChange={(e) => updateVariant(i, "color", e.target.value)}
+            style={{ flex: 1 }}
+          />
+          <input
+            type="number"
+            min="0"
+            placeholder="価格"
+            value={v.price}
+            onChange={(e) => updateVariant(i, "price", e.target.value)}
+            required
+            style={{ flex: 1 }}
+          />
+          {variants.length > 1 && (
+            <button type="button" onClick={() => removeVariant(i)}>
+              削除
+            </button>
+          )}
+        </div>
+      ))}
+      <button type="button" onClick={addVariant} style={{ marginBottom: "1rem" }}>
+        バリアントを追加
+      </button>
+
       {error && <p style={{ color: "red" }}>{error}</p>}
-      <button type="submit">更新する</button>
+      <div>
+        <button type="submit">更新する</button>
+      </div>
     </form>
   );
 }

--- a/frontend/app/products/[id]/edit/EditForm.tsx
+++ b/frontend/app/products/[id]/edit/EditForm.tsx
@@ -90,9 +90,9 @@ export default function EditForm({ product }: Props) {
         />
       </div>
 
-      <h2 style={{ fontSize: "1.1rem" }}>バリアント</h2>
+      <h2 style={{ fontSize: "1.1rem" }}>商品オプション</h2>
       <p style={{ fontSize: "0.85rem", color: "#666" }}>
-        ここから外したバリアントは削除されます。サイズ・カラーの有無は全バリアントで揃える必要があります。
+        ここから外した商品オプションは削除されます。サイズ・カラーの有無は全オプションで揃える必要があります。
       </p>
       {variants.map((v, i) => (
         <div key={i} style={{ display: "flex", gap: "0.5rem", marginBottom: "0.5rem", alignItems: "center" }}>
@@ -111,8 +111,8 @@ export default function EditForm({ product }: Props) {
             style={{ flex: 1 }}
           />
           <input
-            type="number"
-            min="0"
+            type="text"
+            inputMode="numeric"
             placeholder="価格"
             value={v.price}
             onChange={(e) => updateVariant(i, "price", e.target.value)}
@@ -127,7 +127,7 @@ export default function EditForm({ product }: Props) {
         </div>
       ))}
       <button type="button" onClick={addVariant} style={{ marginBottom: "1rem" }}>
-        バリアントを追加
+        商品オプションを追加
       </button>
 
       {error && <p style={{ color: "red" }}>{error}</p>}

--- a/frontend/app/products/[id]/edit/actions.ts
+++ b/frontend/app/products/[id]/edit/actions.ts
@@ -3,9 +3,16 @@
 import { apiFetch } from "@/lib/api";
 import { redirect } from "next/navigation";
 
+type VariantPayload = {
+  id: number | null;
+  size: string | null;
+  color: string | null;
+  price: number;
+};
+
 export async function updateProduct(
   productId: number,
-  formData: { name: string; description: string | null; price: number }
+  formData: { name: string; description: string | null; variants: VariantPayload[] }
 ) {
   const res = await apiFetch(`/api/v1/products/${productId}`, {
     method: "PATCH",

--- a/frontend/app/products/[id]/edit/page.tsx
+++ b/frontend/app/products/[id]/edit/page.tsx
@@ -3,12 +3,19 @@ import { auth } from "@/auth";
 import { apiFetch } from "@/lib/api";
 import EditForm from "./EditForm";
 
+type Variant = {
+  id: number;
+  size: string | null;
+  color: string | null;
+  price: number;
+};
+
 type Product = {
   id: number;
   name: string;
   description: string | null;
-  price: number;
   user_id: number;
+  variants: Variant[];
 };
 
 async function fetchProduct(id: string): Promise<Product | null> {
@@ -28,7 +35,7 @@ export default async function EditProductPage({ params }: { params: Promise<{ id
   if (currentUserId !== String(product.user_id)) notFound();
 
   return (
-    <main style={{ padding: "2rem", fontFamily: "sans-serif", maxWidth: "400px" }}>
+    <main style={{ padding: "2rem", fontFamily: "sans-serif", maxWidth: "600px" }}>
       <h1>商品を編集</h1>
       <EditForm product={product} />
       <p>

--- a/frontend/app/products/[id]/page.tsx
+++ b/frontend/app/products/[id]/page.tsx
@@ -66,15 +66,15 @@ export default async function ProductPage({ params }: { params: Promise<{ id: st
       {product.description && <p>説明: {product.description}</p>}
       <section>
         <h2 style={{ fontSize: "1.1rem" }}>バリアント</h2>
-        <ul>
+        <ul style={{ listStyle: "none", paddingLeft: 0 }}>
           {product.variants.map((v) => (
-            <li key={v.id}>
+            <li key={v.id} style={{ marginBottom: "0.5rem" }}>
               {variantLabel(v)} — {v.price}円
+              <AddToCartButton productVariantId={v.id} />
             </li>
           ))}
         </ul>
       </section>
-      <AddToCartButton productId={product.id} />
       {isOwner && <a href={`/products/${product.id}/edit`}>編集</a>}
       {isOwner && coupons.length === 0 && (
         <a href={`/products/${product.id}/coupons/new`}>クーポン作成</a>

--- a/frontend/app/products/[id]/page.tsx
+++ b/frontend/app/products/[id]/page.tsx
@@ -6,13 +6,25 @@ import DeleteCouponButton from "./coupons/DeleteCouponButton";
 import CopyCouponCodeButton from "./coupons/CopyCouponCodeButton";
 import AddToCartButton from "../../cart/AddToCartButton";
 
+type Variant = {
+  id: number;
+  size: string | null;
+  color: string | null;
+  price: number;
+};
+
 type Product = {
   id: number;
   name: string;
   description: string | null;
-  price: number;
   user_id: number;
+  variants: Variant[];
 };
+
+function variantLabel(v: Variant): string {
+  const parts = [v.size, v.color].filter(Boolean);
+  return parts.length > 0 ? parts.join(" / ") : "標準";
+}
 
 type Coupon = {
   id: number;
@@ -51,8 +63,17 @@ export default async function ProductPage({ params }: { params: Promise<{ id: st
   return (
     <main style={{ padding: "2rem", fontFamily: "sans-serif" }}>
       <h1>{product.name}</h1>
-      <p>価格: {product.price}円</p>
       {product.description && <p>説明: {product.description}</p>}
+      <section>
+        <h2 style={{ fontSize: "1.1rem" }}>バリアント</h2>
+        <ul>
+          {product.variants.map((v) => (
+            <li key={v.id}>
+              {variantLabel(v)} — {v.price}円
+            </li>
+          ))}
+        </ul>
+      </section>
       <AddToCartButton productId={product.id} />
       {isOwner && <a href={`/products/${product.id}/edit`}>編集</a>}
       {isOwner && coupons.length === 0 && (

--- a/frontend/app/products/[id]/page.tsx
+++ b/frontend/app/products/[id]/page.tsx
@@ -75,11 +75,25 @@ export default async function ProductPage({ params }: { params: Promise<{ id: st
           ))}
         </ul>
       </section>
-      {isOwner && <a href={`/products/${product.id}/edit`}>編集</a>}
-      {isOwner && coupons.length === 0 && (
-        <a href={`/products/${product.id}/coupons/new`}>クーポン作成</a>
+      {isOwner && (
+        <div style={{ display: "flex", gap: "0.5rem", marginTop: "1rem" }}>
+          <a
+            href={`/products/${product.id}/edit`}
+            style={{ display: "inline-block", padding: "0.5rem 1rem", border: "1px solid #ccc", borderRadius: "4px", textDecoration: "none", color: "inherit" }}
+          >
+            編集
+          </a>
+          {coupons.length === 0 && (
+            <a
+              href={`/products/${product.id}/coupons/new`}
+              style={{ display: "inline-block", padding: "0.5rem 1rem", border: "1px solid #ccc", borderRadius: "4px", textDecoration: "none", color: "inherit" }}
+            >
+              クーポン作成
+            </a>
+          )}
+          <DeleteButton productId={product.id} />
+        </div>
       )}
-      {isOwner && <DeleteButton productId={product.id} />}
       {isOwner && coupons.length > 0 && (
         <section style={{ marginTop: "2rem" }}>
           <h2>クーポン</h2>

--- a/frontend/app/products/new/actions.ts
+++ b/frontend/app/products/new/actions.ts
@@ -3,7 +3,13 @@
 import { apiFetch } from "@/lib/api";
 import { redirect } from "next/navigation";
 
-export async function createProduct(formData: { name: string; description: string | null; price: number }) {
+type VariantPayload = { size: string | null; color: string | null; price: number };
+
+export async function createProduct(formData: {
+  name: string;
+  description: string | null;
+  variants: VariantPayload[];
+}) {
   const res = await apiFetch("/api/v1/products", {
     method: "POST",
     body: JSON.stringify(formData),

--- a/frontend/app/products/new/page.tsx
+++ b/frontend/app/products/new/page.tsx
@@ -4,24 +4,46 @@ import { useState, FormEvent } from "react";
 import Link from "next/link";
 import { createProduct } from "./actions";
 
+type VariantInput = { size: string; color: string; price: string };
+
 export default function NewProductPage() {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [price, setPrice] = useState("");
+  const [variants, setVariants] = useState<VariantInput[]>([{ size: "", color: "", price: "" }]);
   const [error, setError] = useState<string | null>(null);
+
+  function updateVariant(index: number, key: keyof VariantInput, value: string) {
+    setVariants((prev) => prev.map((v, i) => (i === index ? { ...v, [key]: value } : v)));
+  }
+
+  function addVariant() {
+    setVariants((prev) => [...prev, { size: "", color: "", price: "" }]);
+  }
+
+  function removeVariant(index: number) {
+    setVariants((prev) => prev.filter((_, i) => i !== index));
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setError(null);
     try {
-      await createProduct({ name, description: description || null, price: Number(price) });
+      await createProduct({
+        name,
+        description: description || null,
+        variants: variants.map((v) => ({
+          size: v.size || null,
+          color: v.color || null,
+          price: Number(v.price),
+        })),
+      });
     } catch (e) {
       setError(e instanceof Error ? e.message : "商品の作成に失敗しました");
     }
   }
 
   return (
-    <main style={{ padding: "2rem", fontFamily: "sans-serif", maxWidth: "400px" }}>
+    <main style={{ padding: "2rem", fontFamily: "sans-serif", maxWidth: "600px" }}>
       <h1>商品を登録</h1>
       <form onSubmit={handleSubmit}>
         <div>
@@ -46,21 +68,51 @@ export default function NewProductPage() {
             style={{ width: "100%", marginBottom: "1rem" }}
           />
         </div>
-        <div>
-          <label htmlFor="price">価格（円）</label>
-          <br />
-          <input
-            id="price"
-            type="number"
-            min="0"
-            value={price}
-            onChange={(e) => setPrice(e.target.value)}
-            required
-            style={{ width: "100%", marginBottom: "1rem" }}
-          />
-        </div>
+
+        <h2 style={{ fontSize: "1.1rem" }}>バリアント</h2>
+        <p style={{ fontSize: "0.85rem", color: "#666" }}>
+          サイズ・カラーは任意（バリアントなしの商品は両方空欄で1件登録）。サイズ・カラーの有無は全バリアントで揃える必要があります。
+        </p>
+        {variants.map((v, i) => (
+          <div key={i} style={{ display: "flex", gap: "0.5rem", marginBottom: "0.5rem", alignItems: "center" }}>
+            <input
+              type="text"
+              placeholder="サイズ（任意）"
+              value={v.size}
+              onChange={(e) => updateVariant(i, "size", e.target.value)}
+              style={{ flex: 1 }}
+            />
+            <input
+              type="text"
+              placeholder="カラー（任意）"
+              value={v.color}
+              onChange={(e) => updateVariant(i, "color", e.target.value)}
+              style={{ flex: 1 }}
+            />
+            <input
+              type="number"
+              min="0"
+              placeholder="価格"
+              value={v.price}
+              onChange={(e) => updateVariant(i, "price", e.target.value)}
+              required
+              style={{ flex: 1 }}
+            />
+            {variants.length > 1 && (
+              <button type="button" onClick={() => removeVariant(i)}>
+                削除
+              </button>
+            )}
+          </div>
+        ))}
+        <button type="button" onClick={addVariant} style={{ marginBottom: "1rem" }}>
+          バリアントを追加
+        </button>
+
         {error && <p style={{ color: "red" }}>{error}</p>}
-        <button type="submit">登録する</button>
+        <div>
+          <button type="submit">登録する</button>
+        </div>
       </form>
       <p>
         <Link href="/products">商品一覧に戻る</Link>

--- a/frontend/app/products/new/page.tsx
+++ b/frontend/app/products/new/page.tsx
@@ -69,9 +69,9 @@ export default function NewProductPage() {
           />
         </div>
 
-        <h2 style={{ fontSize: "1.1rem" }}>バリアント</h2>
+        <h2 style={{ fontSize: "1.1rem" }}>商品オプション</h2>
         <p style={{ fontSize: "0.85rem", color: "#666" }}>
-          サイズ・カラーは任意（バリアントなしの商品は両方空欄で1件登録）。サイズ・カラーの有無は全バリアントで揃える必要があります。
+          サイズ・カラーは任意（オプションなしの商品は両方空欄で1件登録）。サイズ・カラーの有無は全オプションで揃える必要があります。
         </p>
         {variants.map((v, i) => (
           <div key={i} style={{ display: "flex", gap: "0.5rem", marginBottom: "0.5rem", alignItems: "center" }}>
@@ -90,8 +90,8 @@ export default function NewProductPage() {
               style={{ flex: 1 }}
             />
             <input
-              type="number"
-              min="0"
+              type="text"
+              inputMode="numeric"
               placeholder="価格"
               value={v.price}
               onChange={(e) => updateVariant(i, "price", e.target.value)}
@@ -106,7 +106,7 @@ export default function NewProductPage() {
           </div>
         ))}
         <button type="button" onClick={addVariant} style={{ marginBottom: "1rem" }}>
-          バリアントを追加
+          商品オプションを追加
         </button>
 
         {error && <p style={{ color: "red" }}>{error}</p>}

--- a/frontend/app/products/page.tsx
+++ b/frontend/app/products/page.tsx
@@ -9,9 +9,17 @@ type Product = {
   id: number;
   name: string;
   description: string | null;
-  price: number;
+  min_price: number;
+  max_price: number;
   user_id: number;
 };
+
+function formatPrice(product: Product): string {
+  if (product.min_price === product.max_price) {
+    return `${product.min_price}円`;
+  }
+  return `${product.min_price}円 〜 ${product.max_price}円`;
+}
 
 async function fetchProducts(): Promise<Product[]> {
   const res = await apiFetch("/api/v1/products", { cache: "no-store" });
@@ -36,7 +44,7 @@ export default async function ProductsPage() {
               <Link href={`/products/${product.id}`} style={{ color: "blue", textDecoration: "underline" }}>
                 <strong>{product.name}</strong>
               </Link>{" "}
-              — {product.price}円
+              — {formatPrice(product)}
               {product.description && <p>{product.description}</p>}
               <AddToCartButton productId={product.id} />
               {currentUserId === String(product.user_id) && <DeleteButton productId={product.id} />}

--- a/frontend/app/products/page.tsx
+++ b/frontend/app/products/page.tsx
@@ -3,7 +3,6 @@ import { auth } from "@/auth";
 import { apiFetch } from "@/lib/api";
 import DeleteButton from "./[id]/DeleteButton";
 import NewProductButton from "./NewProductButton";
-import AddToCartButton from "../cart/AddToCartButton";
 
 type Product = {
   id: number;
@@ -46,7 +45,6 @@ export default async function ProductsPage() {
               </Link>{" "}
               — {formatPrice(product)}
               {product.description && <p>{product.description}</p>}
-              <AddToCartButton productId={product.id} />
               {currentUserId === String(product.user_id) && <DeleteButton productId={product.id} />}
               <span>デバッグ用：user_id={product.user_id}</span>
             </li>


### PR DESCRIPTION
商品にバリアント（サイズ・カラー）を持たせる仕組みを追加。

- product_variants テーブル作成（部分インデックスでパターン別の重複防止）
- 商品作成・編集APIで variants 配列を受け付け
- 商品一覧APIで価格レンジ（min_price / max_price）を返却
- バリアントなしの商品も product_variants レコード1件を持つ
- 既存ショッピング系データはマイグレーション内で全削除

cart_items / order_items はまだ product_id ベースのまま。次コミットで対応する。

refs #100