### PR TITLE
fix: nokogiriを1.19.3にアップデート（CVE対応）

### DIFF
--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -179,9 +179,9 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.5)
-    nokogiri (1.19.2-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
     packwerk (3.3.0)


### PR DESCRIPTION
## Summary

- nokogiri 1.19.2 に以下の脆弱性が検出されたため 1.19.3 に更新
  - GHSA-c4rq-3m3g-8wgx: CSS selector tokenizer の ReDoS（High）
  - GHSA-v2fc-qm4h-8hqv: XSLT transform のメモリリーク（Medium）

## Test plan

- [ ] CI の Backend Security (bundler-audit) がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)